### PR TITLE
fix: allow multiple calls to InstrumentCache in same process

### DIFF
--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -2,6 +2,7 @@ package freelruotel
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cespare/xxhash/v2"
@@ -36,6 +37,10 @@ func TestInstrumentCache(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Reset global state for test isolation
+			registry.reset()
+			metricsRegistered.Store(false)
+
 			// Create manual reader to collect metrics
 			reader := metric.NewManualReader()
 			provider := metric.NewMeterProvider(metric.WithReader(reader))
@@ -125,4 +130,213 @@ func mustCreateSyncedCache() *freelru.SyncedLRU[string, string] {
 		panic(err)
 	}
 	return cache
+}
+
+func TestInstrumentMultipleCaches(t *testing.T) {
+	// Reset global state for test isolation
+	registry.reset()
+	metricsRegistered.Store(false)
+
+	// Create manual reader to collect metrics
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+
+	// Create multiple caches
+	cache1 := mustCreateLRUCache()
+	cache2 := mustCreateSyncedCache()
+	cache3 := mustCreateShardedCache()
+
+	// Instrument all caches - this should not cause errors
+	err := InstrumentCache(cache1, "cache1", WithMeterProvider(provider))
+	if err != nil {
+		t.Fatalf("Failed to instrument cache1: %v", err)
+	}
+
+	err = InstrumentCache(cache2, "cache2", WithMeterProvider(provider))
+	if err != nil {
+		t.Fatalf("Failed to instrument cache2: %v", err)
+	}
+
+	err = InstrumentCache(cache3, "cache3", WithMeterProvider(provider))
+	if err != nil {
+		t.Fatalf("Failed to instrument cache3: %v", err)
+	}
+
+	// Use the caches to generate different metrics
+	cache1.Add("key1", "value1")
+	cache1.Get("key1") // hit for cache1
+
+	cache2.Add("key2", "value2")
+	cache2.Get("missing") // miss for cache2
+
+	cache3.Add("key3", "value3")
+	cache3.Get("key3") // hit for cache3
+
+	// Collect and verify metrics
+	rm := &metricdata.ResourceMetrics{}
+	err = reader.Collect(context.Background(), rm)
+	if err != nil {
+		t.Fatalf("Failed to collect metrics: %v", err)
+	}
+
+	if len(rm.ScopeMetrics) == 0 {
+		t.Fatal("No metrics were exported")
+	}
+
+	metrics := rm.ScopeMetrics[0].Metrics
+	if len(metrics) == 0 {
+		t.Fatal("No cache metrics were exported")
+	}
+
+	// Verify all expected metrics are present
+	expectedMetrics := []string{"cache.hit", "cache.miss", "cache.insert", "cache.eviction", "cache.collision", "cache.removal"}
+	foundMetrics := make(map[string]*metricdata.Metrics)
+	
+	for i := range metrics {
+		for _, expectedMetric := range expectedMetrics {
+			if metrics[i].Name == expectedMetric {
+				foundMetrics[expectedMetric] = &metrics[i]
+			}
+		}
+	}
+
+	// Check that all metrics are found
+	for _, expectedMetric := range expectedMetrics {
+		if foundMetrics[expectedMetric] == nil {
+			t.Errorf("Expected metric %s not found", expectedMetric)
+		}
+	}
+
+	expectedCaches := []string{"cache1", "cache2", "cache3"}
+
+	// Verify each metric has data points for all cache names
+	for metricName, metric := range foundMetrics {
+		if metric == nil {
+			continue
+		}
+		
+		data := metric.Data.(metricdata.Sum[int64])
+		
+		// Check that we have observations for all caches
+		if len(data.DataPoints) != len(expectedCaches) {
+			t.Errorf("Metric %s: expected %d data points for different caches, got %d", 
+				metricName, len(expectedCaches), len(data.DataPoints))
+		}
+
+		// Verify all expected cache names are present in this metric
+		cacheNames := make(map[string]bool)
+		for _, dp := range data.DataPoints {
+			for _, attr := range dp.Attributes.ToSlice() {
+				if attr.Key == "cache_name" {
+					cacheNames[attr.Value.AsString()] = true
+				}
+			}
+		}
+
+		for _, expectedCache := range expectedCaches {
+			if !cacheNames[expectedCache] {
+				t.Errorf("Metric %s: expected cache name %s not found in metrics", metricName, expectedCache)
+			}
+		}
+	}
+}
+
+func TestInstrumentCachesConcurrent(t *testing.T) {
+	// Reset global state for test isolation
+	registry.reset()
+	metricsRegistered.Store(false)
+
+	// Create manual reader to collect metrics
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+
+	// Test concurrent calls to InstrumentCache
+	const numGoroutines = 10
+	const cachesPerGoroutine = 5
+
+	errChan := make(chan error, numGoroutines)
+	
+	for i := 0; i < numGoroutines; i++ {
+		go func(goroutineID int) {
+			for j := 0; j < cachesPerGoroutine; j++ {
+				cache := mustCreateLRUCache()
+				cacheName := fmt.Sprintf("cache_g%d_c%d", goroutineID, j)
+				
+				err := InstrumentCache(cache, cacheName, WithMeterProvider(provider))
+				if err != nil {
+					errChan <- fmt.Errorf("goroutine %d, cache %d: %v", goroutineID, j, err)
+					return
+				}
+				
+				// Use the cache to generate some metrics
+				cache.Add("key", "value")
+				cache.Get("key")
+			}
+			errChan <- nil
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < numGoroutines; i++ {
+		if err := <-errChan; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Collect metrics and verify all caches are tracked
+	rm := &metricdata.ResourceMetrics{}
+	err := reader.Collect(context.Background(), rm)
+	if err != nil {
+		t.Fatalf("Failed to collect metrics: %v", err)
+	}
+
+	if len(rm.ScopeMetrics) == 0 {
+		t.Fatal("No metrics were exported")
+	}
+
+	// Should have metrics for all created caches
+	expectedCacheCount := numGoroutines * cachesPerGoroutine
+	
+	// Verify all expected metrics are present and have correct number of data points
+	expectedMetrics := []string{"cache.hit", "cache.miss", "cache.insert", "cache.eviction", "cache.collision", "cache.removal"}
+	
+	for _, expectedMetric := range expectedMetrics {
+		var foundMetric *metricdata.Metrics
+		for i := range rm.ScopeMetrics[0].Metrics {
+			if rm.ScopeMetrics[0].Metrics[i].Name == expectedMetric {
+				foundMetric = &rm.ScopeMetrics[0].Metrics[i]
+				break
+			}
+		}
+
+		if foundMetric == nil {
+			t.Errorf("Metric %s not found", expectedMetric)
+			continue
+		}
+
+		data := foundMetric.Data.(metricdata.Sum[int64])
+		if len(data.DataPoints) != expectedCacheCount {
+			t.Errorf("Metric %s: expected %d cache data points, got %d", 
+				expectedMetric, expectedCacheCount, len(data.DataPoints))
+		}
+
+		// Verify all cache names are unique
+		cacheNames := make(map[string]bool)
+		for _, dp := range data.DataPoints {
+			for _, attr := range dp.Attributes.ToSlice() {
+				if attr.Key == "cache_name" {
+					cacheName := attr.Value.AsString()
+					if cacheNames[cacheName] {
+						t.Errorf("Metric %s: duplicate cache name %s found", expectedMetric, cacheName)
+					}
+					cacheNames[cacheName] = true
+				}
+			}
+		}
+
+		if len(cacheNames) != expectedCacheCount {
+			t.Errorf("Metric %s: expected %d unique cache names, got %d", 
+				expectedMetric, expectedCacheCount, len(cacheNames))
+		}
+	}
 }

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,41 @@
+package freelruotel
+
+import "sync"
+
+// instrumentedCache holds a cache instance with its name
+type instrumentedCache struct {
+	cache MetricsProvider
+	name  string
+}
+
+// cacheRegistry manages a collection of instrumented caches with thread-safe access
+type cacheRegistry struct {
+	sync.RWMutex
+	caches []instrumentedCache
+}
+
+// add appends a new cache to the registry
+func (r *cacheRegistry) add(cache MetricsProvider, name string) {
+	r.Lock()
+	r.caches = append(r.caches, instrumentedCache{
+		cache: cache,
+		name:  name,
+	})
+	r.Unlock()
+}
+
+// forEach iterates over all caches with read lock
+func (r *cacheRegistry) forEach(fn func(instrumentedCache)) {
+	r.RLock()
+	defer r.RUnlock()
+	for _, ic := range r.caches {
+		fn(ic)
+	}
+}
+
+// reset clears all caches (used in tests)
+func (r *cacheRegistry) reset() {
+	r.Lock()
+	r.caches = nil
+	r.Unlock()
+}


### PR DESCRIPTION
## Summary

Fixes a critical bug where calling `InstrumentCache` multiple times within the same process would fail due to attempting to register OpenTelemetry metrics with duplicate names.

Previously, each call to `InstrumentCache` tried to register the same metric names (`cache.hit`, `cache.miss`, etc.), causing errors on subsequent calls. Now the library properly handles multiple cache instances by:

- Registering metrics only once globally
- Maintaining a registry of all instrumented caches  
- Using callbacks that iterate over all registered caches
- Differentiating caches via unique `cache_name` attributes

## Changes

- **Add `cacheRegistry`**: Thread-safe container for managing multiple cache instances
- **Use `atomic.Bool`**: Efficient thread-safe flag for one-time metrics registration
- **Global metrics registration**: Register each metric type only once with callbacks
- **Per-cache attributes**: Each cache gets unique `cache_name` label in metrics
- **Code organization**: Extract registry to separate file, extract metrics registration function
- **Comprehensive testing**: Add tests for multiple caches and concurrent access

## Test Coverage

- ✅ Multiple cache instances (3 different cache types)
- ✅ Concurrent instrumentation (50 caches across 10 goroutines)  
- ✅ All 6 metric types verified for each cache
- ✅ Thread-safety with race detection
- ✅ Unique `cache_name` attributes validation

## Breaking Changes

None. This is a backward-compatible bug fix.

## Performance Impact

- Improved: No mutex contention after initial registration (atomic operations only)
- Improved: Single set of metrics instead of duplicates per cache
- Minimal: Small overhead for iterating registered caches in callbacks

🤖 Generated with [Claude Code](https://claude.ai/code)